### PR TITLE
Strip trailing newlines from edited text

### DIFF
--- a/edd
+++ b/edd
@@ -107,7 +107,8 @@ edit() {
 
     # Read the clipboard
     # (nohup necessary to serve the content if window closed)
-    nohup xclip -selection clipboard -i < "$file" &>/dev/null
+    awk 'NR>1{print PREV} {PREV=$0} END{printf("%s",$0)}' "${file}" \
+        | nohup xclip -selection clipboard -i &>/dev/null
 }
 
 # Decide what to do


### PR DESCRIPTION
Uses `awk` to remove trailing newlines from edited text. It should work on any version of awk since I don't think it depends on any GNU awk specifics. 
