### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,6 @@ current_version_command: ["make", "packit-version"]
 actions:
   create-archive:
   - make packit-tarball
-  - make packit-path
 
 jobs:
 - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,4 +1,18 @@
+specfile_path: edd.spec
+synced_files:
+- edd.spec
+- .packit.yaml
+
 downstream_package_name: edd
+upstream_package_name: edd
+
+current_version_command: ["make", "packit-version"]
+
+actions:
+  create-archive:
+  - make packit-tarball
+  - make packit-path
+
 jobs:
 - job: copr_build
   metadata:
@@ -7,8 +21,3 @@ jobs:
     - fedora-31-x86_64
     - fedora-rawhide-x86_64
   trigger: pull_request
-specfile_path: edd.spec
-synced_files:
-- edd.spec
-- .packit.yaml
-upstream_package_name: edd

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,22 +1,12 @@
 specfile_path: edd.spec
-synced_files:
-- edd.spec
-- .packit.yaml
-
-downstream_package_name: edd
-upstream_package_name: edd
-
-current_version_command: ["make", "packit-version"]
 
 actions:
   create-archive:
-  - make packit-tarball
+  - make tarball
 
 jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,14 @@
+downstream_package_name: edd
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
+specfile_path: edd.spec
+synced_files:
+- edd.spec
+- .packit.yaml
+upstream_package_name: edd

--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,13 @@ push: packages
 		$(TMP)/SOURCES/$(PACKAGE).tar.bz2 \
 		$(PUSH_URL)/download
 
+# Packit stuff
+packit-tarball: tarball
+	mv $(TMP)/SOURCES/$(PACKAGE).tar.bz2 .
+packit-path:
+	@printf "$(PACKAGE).tar.bz2"
+packit-version:
+	@printf "$(VERSION)"
+
 clean:
 	rm -rf $(TMP)

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,7 @@ push: packages
 
 # Packit stuff
 packit-tarball: tarball
-	mv $(TMP)/SOURCES/$(PACKAGE).tar.bz2 .
-packit-path:
-	@printf "$(PACKAGE).tar.bz2"
+	@printf "$(shell realpath $(TMP)/SOURCES/$(PACKAGE).tar.bz2)\n"
 packit-version:
 	@printf "$(VERSION)"
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build:
 
 tarball: build
 	cd $(TMP) && tar cfj SOURCES/$(PACKAGE).tar.bz2 $(PACKAGE)
+	@printf "$(shell realpath $(TMP)/SOURCES/$(PACKAGE).tar.bz2)\n"
 
 rpm: tarball
 	rpmbuild --define '_topdir $(TMP)' -bb edd.spec
@@ -46,12 +47,6 @@ push: packages
 		$(TMP)/RPMS/noarch/$(PACKAGE)* \
 		$(TMP)/SOURCES/$(PACKAGE).tar.bz2 \
 		$(PUSH_URL)/download
-
-# Packit stuff
-packit-tarball: tarball
-	@printf "$(shell realpath $(TMP)/SOURCES/$(PACKAGE).tar.bz2)\n"
-packit-version:
-	@printf "$(VERSION)"
 
 clean:
 	rm -rf $(TMP)


### PR DESCRIPTION

Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact @packit-service
